### PR TITLE
Kill xml documentation warnings - Add SemVer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
 obj/
+*.suo

--- a/SharpTox/Core/ToxNode.cs
+++ b/SharpTox/Core/ToxNode.cs
@@ -30,7 +30,6 @@ namespace SharpTox.Core
         /// <param name="address"></param>
         /// <param name="port"></param>
         /// <param name="public_key"></param>
-        /// <param name="ipv6enabled"></param>
         public ToxNode(string address, int port, ToxKey public_key)
         {
             Address = address;

--- a/SharpTox/Dns/ToxDns.cs
+++ b/SharpTox/Dns/ToxDns.cs
@@ -23,6 +23,9 @@ namespace SharpTox.Dns
                 throw new Exception("Could not create a new tox_dns3 instance with the provided public_key");
         }
 
+        /// <summary>
+        /// Disposes non-managed resources
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);

--- a/SharpTox/Properties/AssemblyInfo.cs
+++ b/SharpTox/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("SharpTox")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Managed wrapper for the Tox Library")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SharpTox")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyCopyright("Copyright © 2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -34,3 +34,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+// SemVer
+[assembly: AssemblyInformationalVersion("1.0.0-Alpha")]


### PR DESCRIPTION
MIT licensed contribution

Semantic Versioning on AssemblyInformationalVersion (see https://github.com/mojombo/semver)
Fix xml documentation warnings
Ignore visual studio generated .suo files
